### PR TITLE
Remove call to deleted function in example

### DIFF
--- a/industrial_benchmark_python/example.py
+++ b/industrial_benchmark_python/example.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 from IDS import IDS
 import numpy as np
-import pylab as plt
+import matplotlib.pyplot as plt
 '''
 The MIT License (MIT)
 

--- a/industrial_benchmark_python/example.py
+++ b/industrial_benchmark_python/example.py
@@ -41,9 +41,6 @@ for k in range(n_trajectories):
         markovStates = env.step(at)
         data[k,t] = env.visibleState()[-1]
 
-        all_States = env.allStates()
-
-
 plt.plot(data.T)
 plt.xlabel('T')
 plt.ylabel('Reward')


### PR DESCRIPTION
Script doesn't run without this change. Furthermore, I'd suggest to swap out the dependency of `pylab` with `matplotlib.pyplot`. pip didn't find any `pylab` package to install for me.